### PR TITLE
Added backref for sequences

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -162,7 +162,7 @@ def sequence():
 
         return render_template(
             "sequence.html",
-            title="Sequence Search (" + request.form["search_string"] + ")",
+            title=f"Sequence Search ( {request.form['search_string']} )",
             sequences=sequences,
             vendor_count=vendor_count,
             sequence_count=sequence_count,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,27 +9,28 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///sequences.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)
 
-STRING_FAIL = 'fail'
-STRING_SUCCESS = 'success'
+STRING_FAIL = "fail"
+STRING_SUCCESS = "success"
 
 
 class Vendor(db.Model):  # type: ignore
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     name = db.Column(db.String(120), unique=True, index=True, nullable=False)
-    urls = db.relationship('BaseUrl', backref='vendor')
+    urls = db.relationship("BaseUrl", backref="vendor", lazy=True)
+    sequences = db.relationship("Sequence", backref="vendor", lazy=True)
 
     def __repr__(self):
-        return f"<Vendor %r>" % self.name
+        return f"<Vendor {self.name}>"
 
 
 class BaseUrl(db.Model):  # type: ignore
-    __table_name__ = 'Base__Url'
+    __table_name__ = "Base__Url"
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     url = db.Column(db.String, nullable=False, unique=True)
     vendor_id = db.Column(db.Integer, db.ForeignKey("vendor.id"), nullable=False)
 
     def __repr__(self):
-        return f"<BaseUrl %r>" % self.url
+        return f"<BaseUrl {self.url}>"
 
 
 class Sequence(db.Model):  # type: ignore
@@ -41,24 +42,34 @@ class Sequence(db.Model):  # type: ignore
     first_seen = db.Column(db.String, nullable=True)
     price = db.Column(db.String, nullable=True)
     __table_args__ = (
-        db.UniqueConstraint('vendor_id', 'name', 'link',  name='sequence_seq_store_idx'),
+        db.UniqueConstraint("vendor_id", "name", "link", name="sequence_seq_store_idx"),
     )
     #  CREATE UNIQUE INDEX "sequence_seq_store_id" ON "sequence" ( "vendor_id",  "name",  "link")
 
     def __repr__(self):
-        return f"<Sequence() %r %r>" % (self.name, self.link)
+        return f"<Sequence() {self.name} {self.link}>"
 
 
 @app.route("/")
 def index():
-    sequences = Sequence.query.join(Vendor)\
-        .add_columns(Sequence.id, Sequence.name, Sequence.link, Vendor.name.label("vendor_name"),
-                     func.substr(Sequence.last_updated, 1, 10).label("last_updated"),
-                     func.coalesce(Sequence.price, '-').label("price"),
-                     (func.date(func.current_date(), '-2 months') <
-                     func.coalesce(func.date(Sequence.first_seen), func.current_date())).label("is_new"),
-                     func.substr(Sequence.first_seen, 1, 10).label("first_seen")) \
-        .order_by(Sequence.first_seen.desc()).limit(25)
+    sequences = (
+        Sequence.query.join(Vendor)
+        .add_columns(
+            Sequence.id,
+            Sequence.name,
+            Sequence.link,
+            Vendor.name.label("vendor_name"),
+            func.substr(Sequence.last_updated, 1, 10).label("last_updated"),
+            func.coalesce(Sequence.price, "-").label("price"),
+            (
+                func.date(func.current_date(), "-2 months")
+                < func.coalesce(func.date(Sequence.first_seen), func.current_date())
+            ).label("is_new"),
+            func.substr(Sequence.first_seen, 1, 10).label("first_seen"),
+        )
+        .order_by(Sequence.first_seen.desc())
+        .limit(25)
+    )
     vendor_count = Vendor.query.count()
     sequence_count = Sequence.query.count()
 
@@ -92,7 +103,7 @@ def register_vendor():
 
 @app.route("/register-url", methods=["GET", "POST"])
 def register_url():
-    if request.method == 'POST':
+    if request.method == "POST":
         form = request.form
         if form["url"] and form["vendor_id"]:
             baseurl = BaseUrl(url=form["url"], vendor_id=form["vendor_id"])
@@ -103,9 +114,13 @@ def register_url():
             return "Missing values."
     else:
         v = Vendor.query.order_by(Vendor.name)
-        u = BaseUrl.query.join(Vendor).add_columns(Vendor.name.label("vendor_name"))\
-            .order_by(Vendor.name, BaseUrl.url).all()
-    return render_template('urls.html', vendors=v, baseurls=u)
+        u = (
+            BaseUrl.query.join(Vendor)
+            .add_columns(Vendor.name.label("vendor_name"))
+            .order_by(Vendor.name, BaseUrl.url)
+            .all()
+        )
+    return render_template("urls.html", vendors=v, baseurls=u)
 
 
 @app.route("/search", methods=["GET", "POST"])
@@ -113,33 +128,45 @@ def sequence():
     if request.method == "POST":
         ss = request.form["search_string"]
 
-        looking_for = '%{0}%'.format(ss)
+        looking_for = "%{0}%".format(ss)
         weeksago = datetime.timedelta(weeks=6)
         print(weeksago)
 
-        sequences = Sequence.query.join(Vendor)\
-            .add_columns(Sequence.id, Sequence.name, Sequence.link,
-                         func.substr(Sequence.last_updated, 1, 10).label("last_updated"),
-                         Vendor.name.label("vendor_name"),
-                         func.coalesce(Sequence.price, '-').label("price"),
-                         (func.date(func.current_date(), '-2 months') <
-                          func.coalesce(func.date(Sequence.first_seen), func.current_date())).label("is_new"),
-                         func.substr(Sequence.first_seen, 1, 10).label("first_seen")) \
-            .filter(or_(Sequence.name.ilike(looking_for),
-                        Vendor.name.ilike(looking_for),
-                        Sequence.price.ilike(looking_for)))\
+        sequences = (
+            Sequence.query.join(Vendor)
+            .add_columns(
+                Sequence.id,
+                Sequence.name,
+                Sequence.link,
+                func.substr(Sequence.last_updated, 1, 10).label("last_updated"),
+                Vendor.name.label("vendor_name"),
+                func.coalesce(Sequence.price, "-").label("price"),
+                (
+                    func.date(func.current_date(), "-2 months")
+                    < func.coalesce(func.date(Sequence.first_seen), func.current_date())
+                ).label("is_new"),
+                func.substr(Sequence.first_seen, 1, 10).label("first_seen"),
+            )
+            .filter(
+                or_(
+                    Sequence.name.ilike(looking_for),
+                    Vendor.name.ilike(looking_for),
+                    Sequence.price.ilike(looking_for),
+                )
+            )
             .order_by(Vendor.name, Sequence.name)
+        )
 
         vendor_count = Vendor.query.count()
         sequence_count = Sequence.query.count()
 
         return render_template(
-             "sequence.html",
-             title="Sequence Search (" + request.form["search_string"] + ")",
-             sequences=sequences,
-             vendor_count=vendor_count,
-             sequence_count=sequence_count,
-         )
+            "sequence.html",
+            title="Sequence Search (" + request.form["search_string"] + ")",
+            sequences=sequences,
+            vendor_count=vendor_count,
+            sequence_count=sequence_count,
+        )
 
     return render_template("sequence.html", title="Find A Sequence")
 
@@ -157,7 +184,7 @@ def session_commit():
         return jsonify(meta=STRING_FAIL)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Creating database")
     db.create_all()
     app.run(debug=True, port=5000)


### PR DESCRIPTION
Didn't have much luck cleaning up the scrapers so taking a different approach.  Eventually I'll look at moving them so they are integrated into the flask app itself so they will be callable via APIs that can eventually wrapped with some auth.

For now I've done a minior tweak on the Vendor model to add a sequences backref.  This allows sqlalchemy to hide some of the complexity in joins that will be addressed later.  No changes to the DB are needed for this.

Sample usage.
`>>> Vendor.query.first()
<Vendor BlinkySequences>
>>> x = Vendor.query.first()
>>> x.sequences
[<Sequence() Jingle Bells Colton Dixon https://blinkysequences.com/product/jingle-bells-colton-dixon-sequence/>, <Sequence() Merry Christmas Ed Sheeran & Elton John https://blinkysequences.com/product/merry-christmas-ed-sheeran-elton-john/>, <Sequence() Santa Clause Is Coming To Town Andrea Bocelli https://blinkysequences.com/product/santa-clause-is-coming-to-town-andrea-bocelli/>]`